### PR TITLE
Feature: Add support for environment secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,80 @@ jobs:
         run: echo "::error::Expected HTTP status code 204 got
           ${{steps.self.outputs.status}}"; exit 1
 
+  test_environment_create:
+    name: test environment secret
+    runs-on: ubuntu-latest
+    needs: build
+
+    env:
+      ENVIRONMENT_NAME: test
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: main
+          path: dist
+
+      - name: Get repository info
+        uses: octokit/request-action@v2.x
+        id: get_repo
+        with:
+          route: GET /repos/:repository
+          repository: ${{ github.repository }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.PA_TOKEN_PIPELINE }}
+
+      - name: Parse repository id
+        run: echo "REPOSITORY_ID=${{ fromJson(steps.get_repo.outputs.data).id }}" >> $GITHUB_ENV
+
+      - name: Create test environment
+        uses: octokit/request-action@v2.x
+        with:
+          route: PUT /repos/:repository/environments/:environment_name
+          repository: ${{ github.repository }}
+          environment_name: ${{ env.ENVIRONMENT_NAME }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.PA_TOKEN_PIPELINE }}
+
+      - name: Create an environment secret
+        id: self
+        uses: ./
+        with:
+          name: TEST_${{ github.sha }}
+          value: test
+          environment: ${{ env.ENVIRONMENT_NAME }}
+          pa_token: ${{ secrets.PA_TOKEN_PIPELINE }}
+
+      - name: Assert action output
+        if: steps.self.outputs.status != '201'
+        run: echo "::error::Expected HTTP status code 201 got
+          ${{steps.self.outputs.status}}"; exit 1
+
+      - name: Confirm secret creation
+        uses: octokit/request-action@v2.x
+        with:
+          route: GET /repositories/:repository_id/environments/:environment_name/secrets/:secret_name
+          repository_id: ${{ env.REPOSITORY_ID }}
+          secret_name: TEST_${{ github.sha }}
+          environment_name: ${{ env.ENVIRONMENT_NAME }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.PA_TOKEN_PIPELINE }}
+
+      - name: Delete secret
+        if: always()
+        uses: octokit/request-action@v2.x
+        with:
+          route: DELETE /repositories/:repository_id/environments/:environment_name/secrets/:secret_name
+          repository_id: ${{ env.REPOSITORY_ID }}
+          secret_name: TEST_${{ github.sha }}
+          environment_name: ${{ env.ENVIRONMENT_NAME }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.PA_TOKEN_PIPELINE }}
+
   test_organization:
     name: test organization secret
     runs-on: ubuntu-latest
@@ -190,6 +264,7 @@ jobs:
       - test_repo_location
       - test_update
       - test_organization
+      - test_environment_create
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ steps:
       pa_token: ${{ secrets.PAT_STRATEGIC_AIR_COMMAND }}
 ```
 
+Create an environment secret (in the repository where the workflow file is 
+located):
+```yaml
+steps:
+  - uses: gliech/create-github-secret-action@v1
+    with:
+      name: FORCE_DOME_PASSWORD
+      value: Brightmoon
+      pa_token: ${{ secrets.PA_TOKEN }}
+      environment: production
+```
+
 ## Inputs
 
 #### `name`
@@ -56,6 +68,10 @@ steps:
 Name of a GitHub repository or organization where you want to create/update a
 secret. Expects the notation `owner/repo` for repositories. Defaults to the
 repository that invoked the workflow.
+
+#### `environment`
+Name of the environment where you want to create/update a secret. Not valid
+for organizations and the environment must already exist.
 
 #### `pa_token`
 **(Required)** Personal access token with permission to modify repository or

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
     description: Name of a GitHub repository or organization where you want to
       create/update a secret
     required: false
+  environment:
+    description: Name of the environment where this secret should be created. Only valid for repository secrets
+    required: false
   org_visibility:
     description: Visibility setting for organization secrets. Accepts `all`,
       `private` or a comma-seperated list of GitHub repository IDs


### PR DESCRIPTION
This PR adds support for adding environment secrets to an existing environment by mostly using the same patterns your code did. The main (annoying) difference is that environment secret calls need `repository_id` in addition to the `environment_name`. Environment name is supplied by a new action parameter called `environment` but for the repository id I had to make an additional call to get repo information first.

New octokit methods used, if creating an environment secret:
https://octokit.github.io/rest.js/v18#actions-get-environment-public-key
https://octokit.github.io/rest.js/v18#actions-create-or-update-environment-secret
https://octokit.github.io/rest.js/v18#repos-get